### PR TITLE
Change exposed port to 3000

### DIFF
--- a/packages/web/Dockerfile
+++ b/packages/web/Dockerfile
@@ -6,8 +6,8 @@ RUN npm run build
 
 FROM node:alpine
 LABEL name="bot-dev-server" version="1.0.0"
-ENV PORT=80
-EXPOSE 80
+ENV PORT=3000
+EXPOSE 3000
 ENTRYPOINT npx --no-install serve .
 WORKDIR /webapp/
 RUN npm install serve -g


### PR DESCRIPTION
The documentation states the application is available at port 3000, however the web container only exposes port 80, which is not usable under current advice in the documentation.

This PR changes the port exposed by the web app to 3000, as best practice in javascript applications and reflects the instructions found in the readme.